### PR TITLE
fix: catch the latest version of Axon

### DIFF
--- a/test/rpc/eth_call.test.js
+++ b/test/rpc/eth_call.test.js
@@ -418,7 +418,7 @@ describe("eth_call", function () {
                     data: '',
                 }, 'latest']);
             } catch (error) {
-                expect(error.message).to.include('invalid prefix');
+                expect(error.message).to.include('Hex should start with 0x');
             }
         })
         it("data is 0x0fff,should return 0x", async () => {

--- a/test/rpc/eth_estimateGas.test.js
+++ b/test/rpc/eth_estimateGas.test.js
@@ -410,7 +410,7 @@ describe("eth_estimateGas", function () {
                         data: '',
                     }])
             } catch (error) {
-                expect(error.message).to.include('invalid prefix');
+                expect(error.message).to.include('Hex should start with 0x');
             }
         })
         it("data is 0x0fff,should return gas cost", async () => {

--- a/test/rpc/web3_sha3.test.js
+++ b/test/rpc/web3_sha3.test.js
@@ -32,7 +32,7 @@ describe("web3_sha3", function () {
         try {
             await ethers.provider.send('web3_sha3', ["68656c6c6f20776f726c64"])
         } catch (error) {
-            expect(error.message).to.include('invalid prefix');
+            expect(error.message).to.include('Hex should start with 0x');
         }
     })
 })


### PR DESCRIPTION
Fix [Axon Web3 Compatible Tests](https://github.com/axonweb3/axon/actions/runs/6073074608/job/16474288905#step:12:36292) since axonweb3/axon#1396.

The error message will be "[ProtocolError] Kind: Types Error: Hex should start with 0x".

References:

- [Code#1](https://github.com/axonweb3/axon/blob/b77f29f580e2fc23fdef056d9211f5e47594d325/protocol/src/types/primitive.rs#L155-L156)

  ```rust
  String::deserialize(deserializer)
      .and_then(|s| Hex::from_str(&s).map_err(serde::de::Error::custom))
  ```

- [Code#2](https://github.com/axonweb3/axon/blob/b77f29f580e2fc23fdef056d9211f5e47594d325/protocol/src/types/primitive.rs#L127-129)

  ```rust
  if !Self::is_prefixed(s) {
      return Err(TypesError::HexPrefix.into());
  }
  ```


- [Code#3](https://github.com/axonweb3/axon/blob/b77f29f580e2fc23fdef056d9211f5e47594d325/protocol/src/types/mod.rs#L52-L53)
  
  ```rust
  pub enum TypesError {
      /* ... */
      #[display(fmt = "Hex should start with 0x")]
      HexPrefix,
      /* ... */
  }
  ```

:warning: I don't have development environment of Web3 Compatible Tests, so I didn't do tests before I pushed this PR. :clown_face: